### PR TITLE
bump: Use latest alpine for distro image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,15 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@6.1.4
-  codacy_plugins_test: codacy/plugins-test@0.15.4
+  codacy: codacy/base@9.3.5
+  codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:
   version: 2
   compile_test_deploy:
     jobs:
       - codacy/checkout_and_version
-      - codacy/sbt:
+      - codacy/shell:
           name: publish_docker_local
           cmd: |
             docker build --no-cache -t $CIRCLE_PROJECT_REPONAME:latest -f Dockerfile .

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -sSL https://github.com/upx/upx/releases/download/v3.94/upx-3.94-amd64_
   | tar -x --xz --strip-components 1 upx-3.94-amd64_linux/upx \
   && ./upx --best --ultra-brute /root/.local/bin/codacy-hadolint
 
-FROM alpine:3.14.2 AS distro
+FROM alpine:3.17.0 AS distro
 COPY --from=builder /root/.local/bin/codacy-hadolint /bin/
 RUN adduser -D -u 2004 docker
 COPY codacy-hadolint/docs/ /docs/


### PR DESCRIPTION
Use latest alpine image to remove vulnerabilities.